### PR TITLE
Import all modes to highlightCode.js

### DIFF
--- a/highlightCode.js
+++ b/highlightCode.js
@@ -4,8 +4,8 @@ require("codemirror/mode/meta")
 
 CodeMirror.modeInfo.forEach(element => {
   if (Object.keys(element).some(x => element[x] === "null")) return;
-  let mode = element["mode"];
-  let required = `codemirror/mode/${mode}/${mode}`;
+  const mode = element["mode"];
+  const required = `codemirror/mode/${mode}/${mode}`;
   require(required);
 });
 

--- a/highlightCode.js
+++ b/highlightCode.js
@@ -1,5 +1,7 @@
 const CodeMirror = require("codemirror/addon/runmode/runmode.node");
 
+require("codemirror/mode/meta")
+
 CodeMirror.modeInfo.forEach(element => {
   if (Object.keys(element).some(x => element[x] === "null")) return;
   let mode = element["mode"];
@@ -15,7 +17,7 @@ module.exports = function highlightCode(language, value) {
   let tokenBuf = "";
   const pushElement = (token, style) => {
     elements.push(
-      `<span${style ? ` class="cm-${style}"` : ""}>${token}</span>`
+      `<span ${style ? `class="cm-${style}"` : ""}>${token}</span>`
     );
   };
   CodeMirror.runMode(value, language, (token, style) => {

--- a/highlightCode.js
+++ b/highlightCode.js
@@ -1,19 +1,12 @@
 const CodeMirror = require("codemirror/addon/runmode/runmode.node");
 
-require("codemirror/mode/clike/clike");
-require("codemirror/mode/javascript/javascript");
-require("codemirror/mode/swift/swift");
-require("codemirror/mode/sql/sql");
-require("codemirror/mode/shell/shell");
-require("codemirror/mode/ruby/ruby");
-require("codemirror/mode/python/python");
-require("codemirror/mode/markdown/markdown");
-require("codemirror/mode/erlang/erlang");
-require("codemirror/mode/haskell/haskell");
-require("codemirror/mode/elm/elm");
-require("codemirror/mode/jsx/jsx");
-require("codemirror/mode/go/go");
-require("codemirror/mode/lua/lua");
+CodeMirror.modeInfo.forEach(element => {
+  if (Object.keys(element).some(x => element[x] === "null")) return;
+  let mode = element["mode"];
+  let required = `codemirror/mode/${mode}/${mode}`;
+  require(required);
+});
+
 require("./graphqlMode");
 
 module.exports = function highlightCode(language, value) {


### PR DESCRIPTION
Why not adding all modes to highlightCode.js ?
There's no performance issue, because everything is done serverside when building.